### PR TITLE
Fix mapping of extraGeoms

### DIFF
--- a/src/api/tralis/TralisAPI.js
+++ b/src/api/tralis/TralisAPI.js
@@ -334,7 +334,7 @@ class TralisAPI {
         }
 
         onMessage(
-          Object.keys(this.extraGeoms.map((key) => this.extraGeoms[key])),
+          Object.keys(this.extraGeoms).map((key) => this.extraGeoms[key]),
         );
       }
     });


### PR DESCRIPTION
See SBAHNMW-285

# How to

<!--  Please provide a test link and quick description how to see the change -->
Use mobility-toolbox-js in tralis-live-map with dev environment for REACT_APP_REALTIME_URL where a fake extra geom for the Südring is set. Test, together with bugfix in tralis-live-map https://gitlab.geops.de/geops/tralis-live-map/-/merge_requests/361

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] Everything in ticket description has been fixed. - This is own of the sentry errors.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
