### PR TITLE
Fix reconnecting to websocket

### DIFF
--- a/src/api/tralis/WebSocketConnector.js
+++ b/src/api/tralis/WebSocketConnector.js
@@ -63,7 +63,7 @@ class WebSocketConnector {
     this.websocket.onclose = () => {
       window.clearTimeout(this.reconnectTimeout);
       /** @ignore */
-      this.reconnectTimeout = window.setTimeout(() => this.connect(), 100);
+      this.reconnectTimeout = window.setTimeout(() => this.connect(url), 100);
     };
   }
 


### PR DESCRIPTION
See SBAHNMW-285

# How to

<!--  Please provide a test link and quick description how to see the change -->
Use mobility-toolbox-js in tralis-live-map and manually close the websocket or wait for the onclose callback. The [sentry error
](https://sentry.geops.de/sentry/tralis-frontend/issues/51450/?query=is%3Aunresolved%20event.timestamp%3A2020-09-01) 
`SyntaxError: An invalid or illegal string was specified`

should not occur anymore in the browser console. And probably [this one](https://sentry.geops.de/sentry/tralis-frontend/issues/51261/?query=is%3Aunresolved), too, which I have haven't seen in my browser console.
# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] Everything in ticket description has been fixed. -  This is one of the sentry errors.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
