### PR TITLE
TrajservLayer: Add get/set for apiKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobility-toolbox-js",
   "license": "MIT",
-  "version": "1.1.8",
+  "version": "1.1.9-beta.2",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -189,6 +189,7 @@ const TrajservLayerMixin = (TrackerLayer) =>
         publishedLineName,
         tripNumber,
         operator,
+        apiKey,
       } = options;
       Object.defineProperties(this, {
         showVehicleTraj: {
@@ -254,6 +255,17 @@ const TrajservLayerMixin = (TrackerLayer) =>
           value:
             options.api ||
             new TrajservAPI({ url: options.url, apiKey: options.apiKey }),
+        },
+        apiKey: {
+          get: () => {
+            return apiKey;
+          },
+          set: (newApiKey) => {
+            apiKey = newApiKey;
+            if (this.api) {
+              this.api.apiKey = apiKey;
+            }
+          },
         },
       });
     }


### PR DESCRIPTION
See ROKAS-68

Fix updating the apiKey after switch from react-transit to mobility-toolbox-js for TrajservLayer where the definition of the apiKey property now works with `defineProperties()` instead of `getApiKey()`/`setApiKey()`.

# How to

<!--  Please provide a test link and quick description how to see the change -->
Test with https://github.com/geops/trafimage-maps/pull/795

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [ ] Tests added.
