### PR TITLE
TrajservLayer: Add properties for apiKey and apiKeyName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobility-toolbox-js",
   "license": "MIT",
-  "version": "1.1.8",
+  "version": "1.1.9-beta.1",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/api/trajserv/TrajservAPI.js
+++ b/src/api/trajserv/TrajservAPI.js
@@ -23,14 +23,14 @@ class TrajservAPI {
    * @param {Object} options Options.
    * @param {string} [options.url='https://api.geops.io/tracker/v1'] Service url.
    * @param {string} options.apiKey Access key for [geOps services](https://developer.geops.io/).
-   * @param {string} options.apiKeyName Access key name for [geOps services](https://developer.geops.io/)
+   * @param {string} [options.apiKeyName='key'] Access key name for [geOps services](https://developer.geops.io/)
    */
   constructor(options = {}) {
     /** @ignore */
     this.url = options.url || 'https://api.geops.io/tracker/v1';
     /** @ignore */
     this.apiKey = options.apiKey;
-    this.apiKeyName = options.apiKeyName;
+    this.apiKeyName = options.apiKeyName || 'key';
   }
 
   /**
@@ -38,7 +38,7 @@ class TrajservAPI {
    * @ignore
    */
   fetch(url, params = {}, config) {
-    const urlParams = { ...params, [this.apiKeyName || 'key']: this.apiKey };
+    const urlParams = { ...params, [this.apiKeyName]: this.apiKey };
     return fetch(`${url}?${qs.stringify(urlParams)}`, config).then(
       readJsonResponse,
     );

--- a/src/api/trajserv/TrajservAPI.js
+++ b/src/api/trajserv/TrajservAPI.js
@@ -23,14 +23,12 @@ class TrajservAPI {
    * @param {Object} options Options.
    * @param {string} [options.url='https://api.geops.io/tracker/v1'] Service url.
    * @param {string} options.apiKey Access key for [geOps services](https://developer.geops.io/).
-   * @param {string} options.apiKeyName Access key name for [geOps services](https://developer.geops.io/)
    */
   constructor(options = {}) {
     /** @ignore */
     this.url = options.url || 'https://api.geops.io/tracker/v1';
     /** @ignore */
     this.apiKey = options.apiKey;
-    this.apiKeyName = options.apiKeyName;
   }
 
   /**
@@ -38,7 +36,7 @@ class TrajservAPI {
    * @ignore
    */
   fetch(url, params = {}, config) {
-    const urlParams = { ...params, [this.apiKeyName || 'key']: this.apiKey };
+    const urlParams = { ...params, key: this.apiKey };
     return fetch(`${url}?${qs.stringify(urlParams)}`, config).then(
       readJsonResponse,
     );

--- a/src/api/trajserv/TrajservAPI.js
+++ b/src/api/trajserv/TrajservAPI.js
@@ -23,12 +23,14 @@ class TrajservAPI {
    * @param {Object} options Options.
    * @param {string} [options.url='https://api.geops.io/tracker/v1'] Service url.
    * @param {string} options.apiKey Access key for [geOps services](https://developer.geops.io/).
+   * @param {string} options.apiKeyName Access key name for [geOps services](https://developer.geops.io/)
    */
   constructor(options = {}) {
     /** @ignore */
     this.url = options.url || 'https://api.geops.io/tracker/v1';
     /** @ignore */
     this.apiKey = options.apiKey;
+    this.apiKeyName = options.apiKeyName;
   }
 
   /**
@@ -36,7 +38,7 @@ class TrajservAPI {
    * @ignore
    */
   fetch(url, params = {}, config) {
-    const urlParams = { ...params, key: this.apiKey };
+    const urlParams = { ...params, [this.apiKeyName || 'key']: this.apiKey };
     return fetch(`${url}?${qs.stringify(urlParams)}`, config).then(
       readJsonResponse,
     );

--- a/src/api/trajserv/TrajservAPI.js
+++ b/src/api/trajserv/TrajservAPI.js
@@ -23,14 +23,14 @@ class TrajservAPI {
    * @param {Object} options Options.
    * @param {string} [options.url='https://api.geops.io/tracker/v1'] Service url.
    * @param {string} options.apiKey Access key for [geOps services](https://developer.geops.io/).
-   * @param {string} [options.apiKeyName='key'] Access key name for [geOps services](https://developer.geops.io/)
+   * @param {string} options.apiKeyName Access key name for [geOps services](https://developer.geops.io/)
    */
   constructor(options = {}) {
     /** @ignore */
     this.url = options.url || 'https://api.geops.io/tracker/v1';
     /** @ignore */
     this.apiKey = options.apiKey;
-    this.apiKeyName = options.apiKeyName || 'key';
+    this.apiKeyName = options.apiKeyName;
   }
 
   /**
@@ -38,7 +38,7 @@ class TrajservAPI {
    * @ignore
    */
   fetch(url, params = {}, config) {
-    const urlParams = { ...params, [this.apiKeyName]: this.apiKey };
+    const urlParams = { ...params, [this.apiKeyName || 'key']: this.apiKey };
     return fetch(`${url}?${qs.stringify(urlParams)}`, config).then(
       readJsonResponse,
     );

--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -190,6 +190,7 @@ const TrajservLayerMixin = (TrackerLayer) =>
         tripNumber,
         operator,
         apiKey,
+        apiKeyName,
       } = options;
       Object.defineProperties(this, {
         showVehicleTraj: {
@@ -254,7 +255,11 @@ const TrajservLayerMixin = (TrackerLayer) =>
         api: {
           value:
             options.api ||
-            new TrajservAPI({ url: options.url, apiKey: options.apiKey }),
+            new TrajservAPI({
+              url: options.url,
+              apiKey: options.apiKey,
+              apiKeyName: options.apiKeyName,
+            }),
         },
         apiKey: {
           get: () => {
@@ -264,6 +269,17 @@ const TrajservLayerMixin = (TrackerLayer) =>
             apiKey = newApiKey;
             if (this.api) {
               this.api.apiKey = apiKey;
+            }
+          },
+        },
+        apiKeyName: {
+          get: () => {
+            return apiKeyName;
+          },
+          set: (newApiKeyName) => {
+            apiKeyName = newApiKeyName;
+            if (this.api) {
+              this.api.apiKeyName = apiKeyName;
             }
           },
         },

--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -189,6 +189,7 @@ const TrajservLayerMixin = (TrackerLayer) =>
         publishedLineName,
         tripNumber,
         operator,
+        apiKey,
       } = options;
       Object.defineProperties(this, {
         showVehicleTraj: {
@@ -254,6 +255,17 @@ const TrajservLayerMixin = (TrackerLayer) =>
           value:
             options.api ||
             new TrajservAPI({ url: options.url, apiKey: options.apiKey }),
+        },
+        apiKey: {
+          get: () => {
+            return apiKey;
+          },
+          set: (newApiKey) => {
+            apiKey = newApiKey;
+            if (this.api) {
+              this.api.apiKey = apiKey;
+            }
+          },
         },
       });
     }

--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -190,7 +190,6 @@ const TrajservLayerMixin = (TrackerLayer) =>
         tripNumber,
         operator,
         apiKey,
-        apiKeyName,
       } = options;
       Object.defineProperties(this, {
         showVehicleTraj: {
@@ -255,11 +254,7 @@ const TrajservLayerMixin = (TrackerLayer) =>
         api: {
           value:
             options.api ||
-            new TrajservAPI({
-              url: options.url,
-              apiKey: options.apiKey,
-              apiKeyName: options.apiKeyName,
-            }),
+            new TrajservAPI({ url: options.url, apiKey: options.apiKey }),
         },
         apiKey: {
           get: () => {
@@ -269,17 +264,6 @@ const TrajservLayerMixin = (TrackerLayer) =>
             apiKey = newApiKey;
             if (this.api) {
               this.api.apiKey = apiKey;
-            }
-          },
-        },
-        apiKeyName: {
-          get: () => {
-            return apiKeyName;
-          },
-          set: (newApiKeyName) => {
-            apiKeyName = newApiKeyName;
-            if (this.api) {
-              this.api.apiKeyName = apiKeyName;
             }
           },
         },


### PR DESCRIPTION
See ROKAS-68

Fix updating the apiKey after switch from react-transit to mobility-toolbox-js for TrajservLayer where the definition of the apiKey property now works with `defineProperties()` instead of `getApiKey()`/`setApiKey()`.

Additionally, add property apiKeyName which will be used by https://github.com/geops/trafimage-maps/pull/795

# How to

<!--  Please provide a test link and quick description how to see the change -->
Test with https://github.com/geops/trafimage-maps/pull/795

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [ ] Tests added.
