### PR TITLE
Disptach event 'update copyright' when mapboxlayer set copyright

### DIFF
--- a/src/common/layers/Layer.js
+++ b/src/common/layers/Layer.js
@@ -85,8 +85,12 @@ export default class Layer extends Observable {
         writable: true,
       },
       copyright: {
-        value: copyright,
-        writable: true,
+        get: () => {
+          return this.get('copyright') || copyright;
+        },
+        set: (newCopyright) => {
+          return this.set('copyright', newCopyright);
+        },
       },
       visible: {
         value: visible === undefined ? true : visible,

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -96,6 +96,16 @@ describe('Layer', () => {
     }).toThrow(Error);
   });
 
+  test('should initialize copyright property.', () => {
+    const layer = new Layer({
+      name: 'Layer',
+      olLayer,
+      copyright: '&copy: copyright',
+    });
+
+    expect(layer.copyright).toEqual('&copy: copyright');
+  });
+
   test('should set and get copyright property.', () => {
     const layer = new Layer({
       name: 'Layer',

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -102,7 +102,7 @@ describe('Layer', () => {
       olLayer,
     });
     expect(layer).toBeInstanceOf(Layer);
-    expect(layer.get('copyright')).toEqual(undefined);
+    expect(layer.copyright).toEqual(undefined);
 
     layer.set('copyright', '&copy; OSM Contributors');
     expect(layer.copyright).toEqual('&copy; OSM Contributors');

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -104,7 +104,7 @@ describe('Layer', () => {
     expect(layer).toBeInstanceOf(Layer);
     expect(layer.copyright).toEqual(undefined);
 
-    layer.set('copyright', '&copy; OSM Contributors');
+    layer.copyright = '&copy; OSM Contributors';
     expect(layer.copyright).toEqual('&copy; OSM Contributors');
   });
 });

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -95,4 +95,16 @@ describe('Layer', () => {
       layer.onClick('not of type function');
     }).toThrow(Error);
   });
+
+  test('should set and get copyright property.', () => {
+    const layer = new Layer({
+      name: 'Layer',
+      olLayer,
+    });
+    expect(layer).toBeInstanceOf(Layer);
+    expect(layer.get('copyright')).toEqual(undefined);
+
+    layer.set('copyright', '&copy; OSM Contributors');
+    expect(layer.get('copyright')).toEqual('&copy; OSM Contributors');
+  });
 });

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -105,6 +105,6 @@ describe('Layer', () => {
     expect(layer.get('copyright')).toEqual(undefined);
 
     layer.set('copyright', '&copy; OSM Contributors');
-    expect(layer.get('copyright')).toEqual('&copy; OSM Contributors');
+    expect(layer.copyright).toEqual('&copy; OSM Contributors');
   });
 });

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -249,9 +249,6 @@ export default class MapboxLayer extends Layer {
          * @type {string}
          */
         this.copyright = getCopyrightFromSources(this.mbMap);
-        this.dispatchEvent({
-          type: 'change:copyright',
-        });
       }
       this.dispatchEvent({
         type: 'load',

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -249,6 +249,9 @@ export default class MapboxLayer extends Layer {
          * @type {string}
          */
         this.copyright = getCopyrightFromSources(this.mbMap);
+        this.dispatchEvent({
+          type: 'change:copyright',
+        });
       }
       this.dispatchEvent({
         type: 'load',


### PR DESCRIPTION
# How to
Dispatch 'change:copyright' event as it was in react-spatial, for the copyright component to react on it.

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
