### PR TITLE
Upgrade geops-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "module": "module.js",
   "dependencies": {
-    "@geops/geops-ui": "^0.1.5",
+    "@geops/geops-ui": "^0.1.8",
     "@material-ui/core": "^4.9.14",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.9.14",

--- a/src/doc/App.js
+++ b/src/doc/App.js
@@ -39,17 +39,6 @@ const tabs = [
   },
 ];
 
-const links = [
-  {
-    label: 'Privacy Policy',
-    href: 'https://geops.ch/datenschutz',
-  },
-  {
-    label: 'Imprint',
-    href: 'https://geops.ch/impressum',
-  },
-];
-
 const App = () => {
   const classes = useStyles();
 
@@ -74,7 +63,7 @@ const App = () => {
             <Documentation />
           </Route>
         </Container>
-        <Footer links={links} />
+        <Footer />
       </Router>
     </ThemeProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,19 +1172,15 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@geops/geops-ui@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.5.tgz#104961a9776b0748f274d68e2cf5ddd915a6dbd0"
-  integrity sha512-M6v4FVwC//Han6hizEdHeSy7R2xObYTJCq4zpHZMVlT2Mnwt1tfr1j3I9YvJqcTqAqqVZnUfrt15FOqyL+eFag==
+"@geops/geops-ui@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.8.tgz#4df8f4bb8916d762e8b9667cf744fa8961c3598d"
+  integrity sha512-ms3zDcXThMEoVP4wswdMZNajIlwr1mBlFDmtoe4qS1eN7b6iBgd3I2jJ1zSRSbuhaKMmyw7KX+iJcLv3/jY0zg==
   dependencies:
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
-    node-sass "^4.14.1"
     prop-types "^15.7.2"
-    react "^16.13.1"
-    react-dom "^16.13.1"
     react-router-dom "^5.2.0"
-    typeface-lato "^0.0.75"
     uuid "^8.3.1"
 
 "@hapi/address@^2.1.2":
@@ -10071,7 +10067,7 @@ node-releases@^1.1.58:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.59.tgz#4d648330641cec704bff10f8e4fe28e453ab8e8e"
   integrity sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==
 
-node-sass@4.14.1, node-sass@^4.14.1:
+node-sass@4.14.1:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==


### PR DESCRIPTION
# How to
Updates:
- Upgrade geops-ui to 0.1.8
- geops-ui 0.1.8 includes the footer links by default, so they were removed from react spatial

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
