### PR TITLE
Let the next frame renders the hover vehicle. Don't force the render.

### DIFF
--- a/src/common/Tracker.js
+++ b/src/common/Tracker.js
@@ -156,7 +156,6 @@ export default class Tracker {
   setHoverVehicleId(id) {
     if (id !== this.hoverVehicleId) {
       this.hoverVehicleId = id;
-      this.renderTrajectories();
     }
   }
 


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
In the current tracker example https://mobility-toolbox-js.netlify.app/example/ol-tracker . Zoom in close to bern station then hover vehicles with your mouse fast. You will see the others trains blinking.

This PR Remove this blinking. 

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
