### PR TITLE
Don't load the mapbox map if visible is false

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.0",
+  "version": "1.1.14-beta.1",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.2",
+  "version": "1.1.14-beta.3",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.1",
+  "version": "1.1.14-beta.2",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.5",
+  "version": "1.1.14-beta.6",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.13",
+  "version": "1.1.14-beta.0",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.3",
+  "version": "1.1.14-beta.4",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.1.14-beta.4",
+  "version": "1.1.14-beta.5",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/api/stops/StopsAPI.js
+++ b/src/api/stops/StopsAPI.js
@@ -1,5 +1,5 @@
 import qs from 'query-string';
-import { handleError, readJsonResponse } from '../utils';
+import { handleError, readJsonResponse, cleanParams } from '../utils';
 
 /**
  * Access to the [Stops service](https://developer.geops.io/apis/5dcbd702a256d90001cf1361/).
@@ -27,9 +27,9 @@ class StopsAPI {
    * Append the apiKey before sending the request.
    * @ignore
    */
-  fetch(url, params = {}, config) {
-    const urlParams = { ...params, key: this.apiKey };
-    return fetch(`${url}?${qs.stringify(urlParams)}`, config).then(
+  fetch(params = {}, config) {
+    const urlParams = cleanParams({ ...params, key: this.apiKey });
+    return fetch(`${this.url}?${qs.stringify(urlParams)}`, config).then(
       readJsonResponse,
     );
   }
@@ -42,7 +42,7 @@ class StopsAPI {
    * @returns {Promise<GeoJSONFeature[]>} An array of GeoJSON features with coordinates in [EPSG:4326](http://epsg.io/4326).
    */
   search(params, abortController = {}) {
-    return this.fetch(this.url, params, {
+    return this.fetch(params, {
       signal: abortController.signal,
     })
       .then((featureCollection) => featureCollection.features)

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -20,10 +20,28 @@ export const handleError = (reqType, err) => {
  */
 export const readJsonResponse = (response) => {
   try {
-    return response.json();
+    return response.json().then((data) => {
+      if (data.error) {
+        throw new Error(data.error);
+      }
+      return data;
+    });
   } catch (err) {
     throw new Error(err);
   }
 };
 
-export default { handleError, readJsonResponse };
+/**
+ * Remove undefined values of an object.
+ * @ignore
+ */
+export const cleanParams = (obj) => {
+  const clone = { ...obj };
+  Object.keys(obj).forEach(
+    (key) =>
+      (clone[key] === undefined || clone[key] === null) && delete clone[key],
+  );
+  return clone;
+};
+
+export default { handleError, readJsonResponse, cleanParams };

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -10,7 +10,7 @@ export const handleError = (reqType, err) => {
   // eslint-disable-next-line no-console
   console.warn(`Fetch ${reqType} request failed: `, err);
   // Propagate the error.
-  throw new Error(err);
+  throw err;
 };
 
 /**
@@ -27,7 +27,7 @@ export const readJsonResponse = (response) => {
       return data;
     });
   } catch (err) {
-    throw new Error(err);
+    return Promise.reject(new Error(err));
   }
 };
 

--- a/src/doc/examples/mapbox.js
+++ b/src/doc/examples/mapbox.js
@@ -13,7 +13,8 @@ export default () => {
 
   const layer = new MapboxLayer({
     url: `https://maps.geops.io/styles/travic/style.json?key=${window.apiKey}`,
+    visible: false,
   });
-
+  window.layer = layer;
   map.addLayer(layer);
 };

--- a/src/doc/examples/mapbox.js
+++ b/src/doc/examples/mapbox.js
@@ -13,8 +13,6 @@ export default () => {
 
   const layer = new MapboxLayer({
     url: `https://maps.geops.io/styles/travic/style.json?key=${window.apiKey}`,
-    visible: false,
   });
-  window.layer = layer;
   map.addLayer(layer);
 };

--- a/src/ol/layers/Layer.js
+++ b/src/ol/layers/Layer.js
@@ -30,6 +30,12 @@ class Layer extends LayerCommon {
    * @param {boolean} [options.isBaseLayer=false] If true this layer is a baseLayer.
    * @param {boolean} [options.isQueryable=true] If true feature information can be queried by the react-spatial LayerService. Default is true.
    */
+  constructor(options) {
+    super(options);
+    if (this.olLayer) {
+      this.olLayer.setVisible(this.visible);
+    }
+  }
 
   /**
    * Define layer's properties.
@@ -55,12 +61,6 @@ class Layer extends LayerCommon {
 
     if (!this.map || !this.olLayer) {
       return;
-    }
-
-    if (this.olLayer) {
-      this.map.on('postrender', () => {
-        this.olLayer.setVisible(this.visible);
-      });
     }
 
     this.olListenersKeys.push(

--- a/src/ol/layers/Layer.js
+++ b/src/ol/layers/Layer.js
@@ -30,12 +30,6 @@ class Layer extends LayerCommon {
    * @param {boolean} [options.isBaseLayer=false] If true this layer is a baseLayer.
    * @param {boolean} [options.isQueryable=true] If true feature information can be queried by the react-spatial LayerService. Default is true.
    */
-  constructor(options) {
-    super(options);
-    if (this.olLayer) {
-      this.olLayer.setVisible(this.visible);
-    }
-  }
 
   /**
    * Define layer's properties.
@@ -61,6 +55,12 @@ class Layer extends LayerCommon {
 
     if (!this.map || !this.olLayer) {
       return;
+    }
+
+    if (this.olLayer) {
+      this.map.on('postrender', () => {
+        this.olLayer.setVisible(this.visible);
+      });
     }
 
     this.olListenersKeys.push(

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -156,7 +156,11 @@ export default class MapboxLayer extends Layer {
     if (!this.map || this.mbMap) {
       return;
     }
-
+    if (this.olLayer) {
+      this.map.on('postrender', () => {
+        this.olLayer.setVisible(this.visible);
+      });
+    }
     /**
      * The feature format.
      * @type {ol/format/GeoJSON}
@@ -165,8 +169,15 @@ export default class MapboxLayer extends Layer {
       featureProjection: this.map.getView().getProjection(),
     });
 
-    if (this.map.getTargetElement()) {
+    if (this.map.getTargetElement() && this.visible) {
       this.loadMbMap();
+    } else if (!this.visible) {
+      // On next change of visibility we load the map
+      this.olListenersKeys.push(
+        this.once('change:visible', () => {
+          this.loadMbMap();
+        }),
+      );
     }
 
     this.olListenersKeys.push(

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -170,16 +170,7 @@ export default class MapboxLayer extends Layer {
     });
 
     if (this.map.getTargetElement()) {
-      if (this.visible) {
-        this.loadMbMap();
-      } else {
-        // On next change of visibility we load the map
-        this.olListenersKeys.push(
-          this.once('change:visible', () => {
-            this.loadMbMap();
-          }),
-        );
-      }
+      this.loadMbMap();
     }
 
     this.olListenersKeys.push(
@@ -208,6 +199,15 @@ export default class MapboxLayer extends Layer {
    * @private
    */
   loadMbMap() {
+    if (!this.visible) {
+      // On next change of visibility we load the map
+      this.olListenersKeys.push(
+        this.once('change:visible', () => {
+          this.loadMbMap();
+        }),
+      );
+    }
+
     // If the map hasn't been resized, the center could be [NaN,NaN].
     // We set default good value for the mapbox map, to avoid the app crashes.
     let [x, y] = this.map.getView().getCenter();

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -156,11 +156,7 @@ export default class MapboxLayer extends Layer {
     if (!this.map || this.mbMap) {
       return;
     }
-    if (this.olLayer) {
-      this.map.on('postrender', () => {
-        this.olLayer.setVisible(this.visible);
-      });
-    }
+
     /**
      * The feature format.
      * @type {ol/format/GeoJSON}
@@ -169,15 +165,7 @@ export default class MapboxLayer extends Layer {
       featureProjection: this.map.getView().getProjection(),
     });
 
-    if (this.map.getTargetElement()) {
-      this.loadMbMap();
-    }
-
-    this.olListenersKeys.push(
-      this.map.on('change:target', () => {
-        this.loadMbMap();
-      }),
-    );
+    this.loadMbMap();
 
     this.olListenersKeys.push(
       this.map.on('change:size', () => {
@@ -199,6 +187,13 @@ export default class MapboxLayer extends Layer {
    * @private
    */
   loadMbMap() {
+    if (!this.map.getTargetElement()) {
+      this.olListenersKeys.push(
+        this.map.on('change:target', () => {
+          this.loadMbMap();
+        }),
+      );
+    }
     if (!this.visible) {
       // On next change of visibility we load the map
       this.olListenersKeys.push(

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -187,12 +187,13 @@ export default class MapboxLayer extends Layer {
    * @private
    */
   loadMbMap() {
+    this.olListenersKeys.push(
+      this.map.on('change:target', () => {
+        this.loadMbMap();
+      }),
+    );
+
     if (!this.map.getTargetElement()) {
-      this.olListenersKeys.push(
-        this.map.on('change:target', () => {
-          this.loadMbMap();
-        }),
-      );
       return;
     }
 

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -169,15 +169,17 @@ export default class MapboxLayer extends Layer {
       featureProjection: this.map.getView().getProjection(),
     });
 
-    if (this.map.getTargetElement() && this.visible) {
-      this.loadMbMap();
-    } else if (!this.visible) {
-      // On next change of visibility we load the map
-      this.olListenersKeys.push(
-        this.once('change:visible', () => {
-          this.loadMbMap();
-        }),
-      );
+    if (this.map.getTargetElement()) {
+      if (this.visible) {
+        this.loadMbMap();
+      } else {
+        // On next change of visibility we load the map
+        this.olListenersKeys.push(
+          this.once('change:visible', () => {
+            this.loadMbMap();
+          }),
+        );
+      }
     }
 
     this.olListenersKeys.push(

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -193,7 +193,9 @@ export default class MapboxLayer extends Layer {
           this.loadMbMap();
         }),
       );
+      return;
     }
+
     if (!this.visible) {
       // On next change of visibility we load the map
       this.olListenersKeys.push(
@@ -201,6 +203,7 @@ export default class MapboxLayer extends Layer {
           this.loadMbMap();
         }),
       );
+      return;
     }
 
     // If the map hasn't been resized, the center could be [NaN,NaN].


### PR DESCRIPTION
# How to

MapboxLayer was failing to load correctly with the **visibility: false** option, since the render function in the olLayer to load the mapbox canvas was not called on load.

Fix: The olLayer visibility is set only after the map is fully loaded (on postrender) in the Layer class to ensure the render function in MapboxLayer class is called on load

Tested in react-spatial [preview app](https://deploy-preview-640--react-spatial.netlify.app/) in the BaseLayerSwitcher component, and locally in trafimage-maps 
# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [x] Tests added.
