### PR TITLE
Lucien/vehicule font

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.2.0",
+  "version": "1.2.1-beta.1",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.2.1-beta.2",
+  "version": "1.2.1-beta.4",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.2.1-beta.1",
+  "version": "1.2.1-beta.2",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/common/trackerConfig.js
+++ b/src/common/trackerConfig.js
@@ -140,7 +140,7 @@ export const getTextSize = (ctx, markerSize, text, fontSize) => {
   ctx.font = `bold ${fontSize}px Arial`;
   let newText = ctx.measureText(text);
 
-  const maxiter = 15;
+  const maxiter = 25;
   let i = 0;
 
   while (newText.width > markerSize - 6 && i < maxiter) {


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Ticket: TGSRVI-575

We need to allow the vehicule name to be of a smaller font for long names:
For example in the Netherlands, for Fernverkehr, 'Intercity' and 'Sprinter'


# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
