### PR TITLE
Copyright update fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.2.1",
+  "version": "1.2.2-beta.0",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {


### PR DESCRIPTION
# How to

The copyright update method _updateAttributions_ was causing an infinite rerender in trafimage-maps, since calling setAttributions on the ol source triggers a change event and the olLayer render function.

Fix: A condition was added to the update method, which only calls setAttributions if the copyright changed. Additionally a block variable was added preventing unnecessary mbMap rerenders when the copyright is updated.

# Others

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
