### PR TITLE
WIP: Display cancelled vehicule in green background with red cross

### DIFF
--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -439,7 +439,7 @@ const TrajservLayerMixin = (TrackerLayer) =>
             14,
             Math.min(17, radius * 1.2),
           )}px arial, sans-serif`;
-          ctx.fillStyle = getDelayColor(delay, cancelled);
+          ctx.fillStyle = getDelayColor(delay, cancelled, true);
 
           ctx.strokeStyle = this.delayOutlineColor;
           ctx.lineWidth = 1.5;

--- a/src/common/trackerConfig.js
+++ b/src/common/trackerConfig.js
@@ -156,9 +156,9 @@ export const getTextSize = (ctx, markerSize, text, fontSize) => {
 /**
  * @ignore
  */
-export const getDelayColor = (delayInMs, cancelled) => {
+export const getDelayColor = (delayInMs, cancelled, isText) => {
   if (cancelled) {
-    return '#ff0000';
+    return isText ? '#ff0000' : '#00a00c';
   }
   if (delayInMs >= 3600000) {
     return '#ed004c'; // pink { r: 237, g: 0, b: 76, s: '237,0,76' };

--- a/src/common/trackerConfig.js
+++ b/src/common/trackerConfig.js
@@ -155,10 +155,13 @@ export const getTextSize = (ctx, markerSize, text, fontSize) => {
 
 /**
  * @ignore
+ * @param {number} delayInMs Delay in milliseconds.
+ * @param {boolean} cancelled true if the journey is cancelled.
+ * @param {boolean} isDelayText true if the color is used for delay text of the symbol.
  */
-export const getDelayColor = (delayInMs, cancelled, isText) => {
+export const getDelayColor = (delayInMs, cancelled, isDelayText) => {
   if (cancelled) {
-    return isText ? '#ff0000' : '#00a00c';
+    return isDelayText ? '#ff0000' : '#00a00c';
   }
   if (delayInMs >= 3600000) {
     return '#ed004c'; // pink { r: 237, g: 0, b: 76, s: '237,0,76' };


### PR DESCRIPTION
Display cancelled vehicule in green background with red cross, on 'useDelayStyle' mode

Ticket: TRAFDIV-361
# How to

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
