### PR TITLE
Remove the projection parameter for getFullTrajectory method

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.2.10",
+  "version": "1.2.11-beta.0",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/api/tralis/TralisAPI.js
+++ b/src/api/tralis/TralisAPI.js
@@ -56,9 +56,7 @@ class TralisAPI {
     }
     /** @ignore */
     this.conn = new WebSocketConnector(wsUrl);
-    /** @ignore */
-    this.dfltProjection = 'epsg:3857';
-    this.conn.setProjection(this.dfltProjection);
+    this.conn.setProjection(options.projection || 'epsg:3857');
     /** @ignore */
     this.subscribedStationUic = null;
     /** @ignore */
@@ -312,7 +310,7 @@ class TralisAPI {
    */
   unsubscribeStations() {
     window.clearTimeout(this.stationUpdateTimeout);
-    this.unsubscribe('stations');
+    this.unsubscribe('station');
   }
 
   /**
@@ -391,21 +389,15 @@ class TralisAPI {
    *
    * @param {number} id A vehicle id.
    * @param {TralisMode} mode Tralis mode.
-   * @param {string} projection The epsg code of a projection (ex: EPSG:3857).
    * @returns {Promise<FullTrajectory>} Return a full trajectory.
    */
-  getFullTrajectory(id, mode, projection) {
-    if (projection) {
-      this.conn.setProjection(projection);
-    }
+  getFullTrajectory(id, mode) {
     const params = {
       channel: `full_trajectory${getModeSuffix(mode, TralisModes)}_${id}`,
     };
 
     return new Promise((resolve) => {
       this.conn.get(params, (data) => {
-        // Reset the projection after the request is done.
-        this.conn.setProjection(this.dfltProjection);
         if (data.content) {
           resolve(data.content);
         }

--- a/src/api/tralis/TralisAPI.js
+++ b/src/api/tralis/TralisAPI.js
@@ -43,6 +43,7 @@ class TralisAPI {
    * @param {Object|string} options A string representing the url of the service or an object containing the url and the apiKey.
    * @param {string} options.url Service url.
    * @param {string} options.apiKey Access key for [geOps services](https://developer.geops.io/).
+   * @param {string} [options.projection='epsg:3857'] The epsg code of the projection for features.
    */
   constructor(options = {}) {
     let wsUrl = null;


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Setting a custom projection in getFullTrajectory method set it also for all subscriptions or request made in the same time.
So we have inconsistent responses from the backend, sometimes with a projection sometimes with the default one.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [ ] Tests added.
