### PR TITLE
Use another encoded character for cancelled trains

### DIFF
--- a/src/common/mixins/TrajservLayerMixin.js
+++ b/src/common/mixins/TrajservLayerMixin.js
@@ -453,8 +453,8 @@ const TrajservLayerMixin = (TrackerLayer) =>
           ctx.textAlign = 'left';
           ctx.textBaseline = 'middle';
           ctx.font = `bold ${Math.max(
-            14,
-            Math.min(17, radius * 1.2),
+            cancelled ? 19 : 14,
+            Math.min(cancelled ? 19 : 17, radius * 1.2),
           )}px arial, sans-serif`;
           ctx.fillStyle = getDelayColor(delay, cancelled, true);
 

--- a/src/common/trackerConfig.js
+++ b/src/common/trackerConfig.js
@@ -186,7 +186,7 @@ export const getDelayColor = (delayInMs, cancelled, isDelayText) => {
  */
 export const getDelayText = (delayInMs, cancelled) => {
   if (cancelled) {
-    return String.fromCharCode(10006);
+    return String.fromCodePoint(0x00d7);
   }
   if (delayInMs > 3600000) {
     const rounded = Math.round(delayInMs / 3600000);

--- a/src/doc/examples/ol-tracker.js
+++ b/src/doc/examples/ol-tracker.js
@@ -21,7 +21,6 @@ export default () => {
   const tracker = new TrajservLayer({
     url: 'https://api.geops.io/tracker/v1',
     apiKey: window.apiKey,
-    useDelayStyle: true,
   });
 
   tracker.onClick((vehicle) => {

--- a/src/doc/examples/ol-tracker.js
+++ b/src/doc/examples/ol-tracker.js
@@ -21,6 +21,7 @@ export default () => {
   const tracker = new TrajservLayer({
     url: 'https://api.geops.io/tracker/v1',
     apiKey: window.apiKey,
+    useDelayStyle: true,
   });
 
   tracker.onClick((vehicle) => {


### PR DESCRIPTION
Use another encoded character for cancelled trains

Because previous character was not supported/displayed on all browsers/platforms the same way.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] The new class' members & methods are well documented
- [ ] Tests added.
