### PR TITLE
Always execute the super class terminate function

### DIFF
--- a/__mocks__/mapbox-gl.js
+++ b/__mocks__/mapbox-gl.js
@@ -39,6 +39,8 @@ class Map {
   off() {}
 
   loaded() {}
+
+  remove() {}
 }
 module.exports = {
   Map,

--- a/src/ol/layers/MapboxStyleLayer.js
+++ b/src/ol/layers/MapboxStyleLayer.js
@@ -51,7 +51,7 @@ class MapboxStyleLayer extends Layer {
    * Constructor.
    *
    * @param {Object} options
-   * @param {MapboxLayer} [options.mapboxLayer] The MapboxLayer to use.   *
+   * @param {MapboxLayer} [options.mapboxLayer] The MapboxLayer to use.
    * @param {Function} [options.styleLayersFilter] Filter function to decide which style layer to display.
    */
   constructor(options = {}) {
@@ -72,6 +72,14 @@ class MapboxStyleLayer extends Layer {
      * @private
      */
     this.styleLayersFilter = options.styleLayersFilter;
+
+    /**
+     * Mapbox style layer id where to add the style layers.
+     * See [mapbox.map.addLayer](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#addlayer) documentation.
+     * @type {String}
+     * @private
+     */
+    this.beforeId = options.beforeId;
 
     /**
      * Function to filter features for getFeatureInfoAtCoordinate method.
@@ -250,7 +258,7 @@ class MapboxStyleLayer extends Layer {
     this.styleLayers.forEach((styleLayer) => {
       const { id, source } = styleLayer;
       if (mbMap.getSource(source) && !mbMap.getLayer(id)) {
-        mbMap.addLayer(styleLayer);
+        mbMap.addLayer(styleLayer, this.beforeId);
       }
     });
     applyLayoutVisibility(mbMap, this.visible, this.styleLayersFilter);

--- a/src/ol/layers/MapboxStyleLayer.js
+++ b/src/ol/layers/MapboxStyleLayer.js
@@ -235,7 +235,6 @@ class MapboxStyleLayer extends Layer {
     if (mbMap) {
       mbMap.off('load', this.onLoad);
       this.removeStyleLayers();
-      return;
     }
     super.terminate(map);
   }

--- a/src/ol/layers/MapboxStyleLayer.js
+++ b/src/ol/layers/MapboxStyleLayer.js
@@ -232,12 +232,11 @@ class MapboxStyleLayer extends Layer {
    */
   terminate(map) {
     const { mbMap } = this.mapboxLayer;
-    if (!mbMap) {
+    if (mbMap) {
+      mbMap.off('load', this.onLoad);
+      this.removeStyleLayers();
       return;
     }
-
-    mbMap.off('load', this.onLoad);
-    this.removeStyleLayers();
     super.terminate(map);
   }
 

--- a/src/ol/layers/MapboxStyleLayer.test.js
+++ b/src/ol/layers/MapboxStyleLayer.test.js
@@ -83,11 +83,20 @@ describe('MapboxStyleLayer', () => {
     expect(onClick).toHaveBeenCalledWith(features, layer, coordinate);
   });
 
-  test('should call super class terminate even if the mapboxLayer associated has been terminated before.', () => {
+  test('should call super class terminate function.', () => {
+    layer.init(map);
+    const spy = jest.spyOn(Layer.prototype, 'terminate');
+    layer.terminate(map);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  test('should call super class terminate if the mapboxLayer associated has been terminated before.', () => {
     layer.init(map);
     source.terminate(map);
     const spy = jest.spyOn(Layer.prototype, 'terminate');
     layer.terminate(map);
     expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
   });
 });

--- a/src/ol/layers/MapboxStyleLayer.test.js
+++ b/src/ol/layers/MapboxStyleLayer.test.js
@@ -1,6 +1,7 @@
 import Map from 'ol/Map';
 import View from 'ol/View';
 import mapboxgl from 'mapbox-gl';
+import Layer from './Layer';
 import MapboxLayer from './MapboxLayer';
 import MapboxStyleLayer from './MapboxStyleLayer';
 
@@ -80,5 +81,13 @@ describe('MapboxStyleLayer', () => {
     await map.dispatchEvent(evt);
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith(features, layer, coordinate);
+  });
+
+  test('should call super class terminate even if the mapboxLayer associated has been terminated before.', () => {
+    layer.init(map);
+    source.terminate(map);
+    const spy = jest.spyOn(Layer.prototype, 'terminate');
+    layer.terminate(map);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
terminate function of the super class was not called if the mapboxLayer was terminate before the MapboxStyleLayer.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [x] Tests added.
