### PR TITLE
Abort requests on drawRoute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.7.4",
+  "version": "1.7.5-beta.0",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.7.5-beta.1",
+  "version": "1.7.5-beta.2",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobility-toolbox-js",
   "license": "MIT",
   "description": "Toolbox for JavaScript applications in the domains of mobility and logistics.",
-  "version": "1.7.5-beta.0",
+  "version": "1.7.5-beta.1",
   "main": "index.js",
   "module": "module.js",
   "dependencies": {

--- a/src/doc/examples/ol-routing.html
+++ b/src/doc/examples/ol-routing.html
@@ -1,20 +1,26 @@
- 
 <style>
-  #control-button, #mot-button, #reset-button {
+  #control-button,
+  #mot-button,
+  #reset-button {
     margin: 10px 10px;
   }
 
   .buttons {
     display: flex;
   }
-
 </style>
 <div style="width: 100%; height: 100%; position: relative;">
   <div id="map" style="width: 100%; height: 100%;"></div>
   <div class="buttons">
-    <button id="control-button" type="button" class="geops-ui">Deactivate RoutingControl</button>
-    <button id="mot-button" type="button" class="geops-ui">Switch to foot routing</button>
-    <button id="reset-button" type="button" class="geops-ui">Clear route</button>
+    <button id="control-button" type="button" class="geops-ui">
+      Deactivate RoutingControl
+    </button>
+    <button id="mot-button" type="button" class="geops-ui">
+      Switch to foot routing
+    </button>
+    <button id="reset-button" type="button" class="geops-ui">
+      Clear route
+    </button>
   </div>
   <div id="copyright"></div>
 </div>

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -17,8 +17,7 @@ import RoutingLayer from '../layers/RoutingLayer';
 // @47.37811,8.53935 a station at position 47.37811, 8.53935
 // @47.37811,8.53935$4 track 4 in a station at position 47.37811, 8.53935
 // zürich hb@47.37811,8.53935$8 track 8 in station "Zürich HB" at position 47.37811, 8.53935
-const REGEX_VIA_POINT =
-  /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
+const REGEX_VIA_POINT = /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
 
 // Examples for a single hop:
 //
@@ -288,8 +287,9 @@ class RoutingControl extends Control {
    * @private
    */
   drawRoute() {
-    this.cancelDrawRoute();
     /* Calls RoutingAPI to draw a route using the viaPoints array */
+    this.cancelDrawRoute();
+
     if (!this.viaPoints.length) {
       return null;
     }

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -17,7 +17,8 @@ import RoutingLayer from '../layers/RoutingLayer';
 // @47.37811,8.53935 a station at position 47.37811, 8.53935
 // @47.37811,8.53935$4 track 4 in a station at position 47.37811, 8.53935
 // zürich hb@47.37811,8.53935$8 track 8 in station "Zürich HB" at position 47.37811, 8.53935
-const REGEX_VIA_POINT = /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
+const REGEX_VIA_POINT =
+  /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
 
 // Examples for a single hop:
 //
@@ -321,10 +322,6 @@ class RoutingControl extends Control {
 
     return Promise.all(
       this.graphs.map(([graph], index) => {
-        if (this.abortControllers[graph]) {
-          this.abortControllers[graph].abort();
-        }
-        this.abortControllers[graph] = new AbortController();
         return this.api
           .route(
             {

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -17,7 +17,8 @@ import RoutingLayer from '../layers/RoutingLayer';
 // @47.37811,8.53935 a station at position 47.37811, 8.53935
 // @47.37811,8.53935$4 track 4 in a station at position 47.37811, 8.53935
 // zürich hb@47.37811,8.53935$8 track 8 in station "Zürich HB" at position 47.37811, 8.53935
-const REGEX_VIA_POINT = /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
+const REGEX_VIA_POINT =
+  /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
 
 // Examples for a single hop:
 //
@@ -281,9 +282,8 @@ class RoutingControl extends Control {
 
     // Abort Stops API requests
     this.abortControllers[STOP_FETCH_ABORT_CONTROLLER_KEY]?.abort();
-    this.abortControllers[
-      STOP_FETCH_ABORT_CONTROLLER_KEY
-    ] = new AbortController();
+    this.abortControllers[STOP_FETCH_ABORT_CONTROLLER_KEY] =
+      new AbortController();
 
     this.loading = false;
   }

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -17,8 +17,7 @@ import RoutingLayer from '../layers/RoutingLayer';
 // @47.37811,8.53935 a station at position 47.37811, 8.53935
 // @47.37811,8.53935$4 track 4 in a station at position 47.37811, 8.53935
 // zürich hb@47.37811,8.53935$8 track 8 in station "Zürich HB" at position 47.37811, 8.53935
-const REGEX_VIA_POINT =
-  /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
+const REGEX_VIA_POINT = /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
 
 // Examples for a single hop:
 //
@@ -393,6 +392,7 @@ class RoutingControl extends Control {
               target: this,
             });
             this.onRouteError(error, this);
+            this.loading = false;
           });
       }),
     );

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -17,7 +17,8 @@ import RoutingLayer from '../layers/RoutingLayer';
 // @47.37811,8.53935 a station at position 47.37811, 8.53935
 // @47.37811,8.53935$4 track 4 in a station at position 47.37811, 8.53935
 // zürich hb@47.37811,8.53935$8 track 8 in station "Zürich HB" at position 47.37811, 8.53935
-const REGEX_VIA_POINT = /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
+const REGEX_VIA_POINT =
+  /^([^@$!\n]*)(@?([\d.]+),([\d.]+))?(\$?([a-zA-Z0-9]{0,2}))$/;
 
 // Examples for a single hop:
 //


### PR DESCRIPTION
# How to
setViaPoints with empty or single value arrays draw the route from previous asynchronous routing requests even though the viaPoints are updated.

fix: routing requests are always aborted initially on drawRoute

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [ ] Tests added.
