### PR TITLE
fix: replace init() and terminate() by attachToMap() and removeFromMap()

### DIFF
--- a/src/common/controls/Control.js
+++ b/src/common/controls/Control.js
@@ -111,6 +111,20 @@ class Control extends BaseObject {
   }
 
   /**
+   * Attach the control to the map. Add events, html element ...
+   */
+  attachToMap(map) {
+    this.map = map;
+  }
+
+  /**
+   * Detach the control From the map. Remove events, html element ..
+   */
+  detachFromMap() {
+    this.map = null;
+  }
+
+  /**
    * Add listeners then renders the control.
    * To be defined in inherited classes.
    */

--- a/src/common/controls/Control.test.js
+++ b/src/common/controls/Control.test.js
@@ -45,7 +45,7 @@ describe('Control', () => {
     expect(spy2).toBeCalledTimes(2);
     expect(spy3).toBeCalledTimes(1);
 
-    control.map = null;
+    control.detachFromMap();
     expect(target.childNodes[0]).toBe();
     expect(spy1).toBeCalledTimes(1);
     expect(spy2).toBeCalledTimes(3);
@@ -68,7 +68,7 @@ describe('Control', () => {
     expect(spy2).toBeCalledTimes(2);
     expect(spy3).toBeCalledTimes(1);
 
-    control.map = null;
+    control.detachFromMap();
     expect(target.childNodes[0]).toBe();
     expect(spy1).toBeCalledTimes(1);
     expect(spy2).toBeCalledTimes(3);

--- a/src/common/layers/Layer.js
+++ b/src/common/layers/Layer.js
@@ -171,8 +171,8 @@ export default class Layer extends Observable {
    *
    * @param {ol/Map~Map|mapboxgl.Map} map A map.
    */
-  init(map) {
-    this.terminate();
+  attachToMap(map) {
+    this.detachFromMap();
     /** @ignore */
     this.map = map;
   }
@@ -181,7 +181,7 @@ export default class Layer extends Observable {
    * Terminate what was initialized in init function. Remove layer, events...
    */
   // eslint-disable-next-line class-methods-use-this
-  terminate() {}
+  detachFromMap() {}
 
   /**
    * Get a layer property.

--- a/src/common/layers/Layer.test.js
+++ b/src/common/layers/Layer.test.js
@@ -80,8 +80,8 @@ describe('Layer', () => {
 
   test('should called terminate on initialization.', () => {
     const layer = new Layer({ name: 'Layer', olLayer });
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init();
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -158,7 +158,7 @@ describe('Layer', () => {
     expect(layer.copyright).toEqual('&copy; OSM Contributors');
   });
 
-  describe('#init()', () => {
+  describe('#attachToMap()', () => {
     test('should set map.', () => {
       const layer = new Layer({
         name: 'Layer',
@@ -167,7 +167,7 @@ describe('Layer', () => {
 
       expect(layer.map).toBe(undefined);
       const obj = {};
-      layer.init(obj);
+      layer.attachToMap(obj);
       expect(layer.map).toBe(obj);
     });
 
@@ -176,8 +176,8 @@ describe('Layer', () => {
         name: 'Layer',
         olLayer,
       });
-      const spy = jest.spyOn(layer, 'terminate');
-      layer.init();
+      const spy = jest.spyOn(layer, 'detachFromMap');
+      layer.attachToMap();
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/common/mixins/TralisLayerMixin.js
+++ b/src/common/mixins/TralisLayerMixin.js
@@ -44,12 +44,12 @@ export class TralisLayerInterface {
    *
    * @param {ol/Map~Map} map
    */
-  init(map) {}
+  attachToMap(map) {}
 
   /**
    * Terminate the layer unsubscribing to the Tralis api.
    */
-  terminate() {}
+  detachFromMap() {}
 
   /**
    * Start the clock.
@@ -390,8 +390,8 @@ const TralisLayerMixin = (Base) =>
       this.updateFilters();
     }
 
-    init(map) {
-      super.init(map);
+    attachToMap(map) {
+      super.attachToMap(map);
 
       this.tracker = new Tracker({
         style: (...args) => this.style(...args),
@@ -420,7 +420,7 @@ const TralisLayerMixin = (Base) =>
       );
     }
 
-    terminate() {
+    detachFromMap() {
       document.removeEventListener(
         'visibilitychange',
         this.onDocumentVisibilityChange,
@@ -434,7 +434,7 @@ const TralisLayerMixin = (Base) =>
         context.clearRect(0, 0, canvas.width, canvas.height);
         this.tracker = null;
       }
-      super.terminate();
+      super.detachFromMap();
     }
 
     start() {

--- a/src/doc/components/Home.js
+++ b/src/doc/components/Home.js
@@ -34,7 +34,7 @@ const tracker = new TralisLayer({
   apiKey: window.apiKey,
 });
 
-tracker.init(map);
+tracker.attachToMap(map);
 `;
 
 function MarkdownHeading({ ...props }) {

--- a/src/doc/components/TrackerExample.js
+++ b/src/doc/components/TrackerExample.js
@@ -29,7 +29,7 @@ function TrackerExample() {
       isQueryable: false,
     });
 
-    tracker.init(map);
+    tracker.attachToMap(map);
   }, []);
 
   return <div id="map" className={classes.root} />;

--- a/src/doc/examples/mb-copyright.js
+++ b/src/doc/examples/mb-copyright.js
@@ -24,14 +24,14 @@ export default () => {
   });
 
   // Attach the control to the map
-  control.map = map;
+  control.attachToMap(map);
 
   // Add example button to toggle the copyright control.
   document.getElementById('button').addEventListener('click', () => {
     if (control.map) {
-      control.map = null;
+      control.detachFromMap();
     } else {
-      control.map = map;
+      control.attachToMap(map);
     }
   });
 };

--- a/src/doc/examples/mb-tracker.js
+++ b/src/doc/examples/mb-tracker.js
@@ -15,7 +15,7 @@ export default () => {
   });
 
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   // Define the layer
   const tracker = new TralisLayer({
@@ -24,10 +24,10 @@ export default () => {
   });
 
   // Add the layer to the map
-  tracker.init(map);
+  tracker.attachToMap(map);
 
   // Remove the layer from the map
-  // tracker.terminate(map);
+  // tracker.detachFromMap(map);
 
   // Display informations on click in the console
   tracker.onClick(([feature]) => {

--- a/src/doc/examples/mb-tralis.js
+++ b/src/doc/examples/mb-tralis.js
@@ -14,7 +14,7 @@ export default () => {
   });
 
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   const tracker = new TralisLayer({
     url: '',
@@ -22,7 +22,7 @@ export default () => {
   });
 
   map.on('load', () => {
-    tracker.init(map, 'waterway-name');
+    tracker.attachToMap(map, 'waterway-name');
   });
 
   tracker.onClick(([feature]) => {

--- a/src/doc/examples/ol-copyright.js
+++ b/src/doc/examples/ol-copyright.js
@@ -25,7 +25,7 @@ export default () => {
   });
 
   // Attach to the map
-  control.map = map;
+  control.attachToMap(map);
 
   // Define the Mapbox style to display
   const mapboxLayer = new MaplibreLayer({
@@ -34,7 +34,7 @@ export default () => {
   });
 
   // Display the Mapbox style on the map
-  mapboxLayer.init(map);
+  mapboxLayer.attachToMap(map);
 
   // Toggle the copyright control.
   document.getElementById('button').addEventListener('click', () => {

--- a/src/doc/examples/ol-mapbox-layer.js
+++ b/src/doc/examples/ol-mapbox-layer.js
@@ -15,7 +15,7 @@ export default () => {
 
   // Add copyright control
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   // Define the Mapbox style to display
   const layer = new MaplibreLayer({
@@ -24,5 +24,5 @@ export default () => {
   });
 
   // Display the Mapbox style on the map
-  layer.init(map);
+  layer.attachToMap(map);
 };

--- a/src/doc/examples/ol-mapbox-style-layer.js
+++ b/src/doc/examples/ol-mapbox-style-layer.js
@@ -15,7 +15,7 @@ export default () => {
 
   // Add copyright control
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   // Define the Mapbox style to display
   const mapboxLayer = new MaplibreLayer({
@@ -24,7 +24,7 @@ export default () => {
   });
 
   // Display the style on the map
-  mapboxLayer.init(map);
+  mapboxLayer.attachToMap(map);
 
   // Define the list of Mapbox style layers representing the pois.
   const poiLayer = new MapboxStyleLayer({
@@ -33,7 +33,7 @@ export default () => {
   });
 
   // Display the pois on the map
-  poiLayer.init(map);
+  poiLayer.attachToMap(map);
 
   // Toggle pois visibility
   document.getElementById('button').addEventListener('click', (evt) => {

--- a/src/doc/examples/ol-query.js
+++ b/src/doc/examples/ol-query.js
@@ -24,7 +24,7 @@ export default () => {
 
   // Add copyright control
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   map.on('pointermove', () => {
     map.getTargetElement().style.cursor = '';
@@ -46,7 +46,7 @@ export default () => {
     url: 'https://maps.geops.io/styles/travic_v2/style.json',
     apiKey: window.apiKey,
   });
-  mapboxLayer.init(map);
+  mapboxLayer.attachToMap(map);
 
   const poiLayer = new MapboxStyleLayer({
     visible: true,
@@ -55,7 +55,7 @@ export default () => {
     onHover,
     onClick,
   });
-  poiLayer.init(map);
+  poiLayer.attachToMap(map);
 
   const vectorLayer = new VectorLayer({
     olLayer: new OLVectorLayer({
@@ -79,5 +79,5 @@ export default () => {
     onHover,
     onClick,
   });
-  vectorLayer.init(map);
+  vectorLayer.attachToMap(map);
 };

--- a/src/doc/examples/ol-routing.js
+++ b/src/doc/examples/ol-routing.js
@@ -16,7 +16,7 @@ export default () => {
   const mapboxLayer = new MaplibreLayer({
     url: `https://maps.geops.io/styles/travic_v2/style.json?key=${window.apiKey}`,
   });
-  mapboxLayer.init(map);
+  mapboxLayer.attachToMap(map);
 
   const copyright = new CopyrightControl();
   copyright.map = map;
@@ -25,7 +25,7 @@ export default () => {
     element: document.createElement('div'),
     apiKey: `${window.apiKey}`,
   });
-  control.map = map;
+  control.attachToMap(map);
 
   control.addViaPoint([950476.4055933182, 6003322.253698345]);
   control.addViaPoint([950389.0813034325, 6003656.659274571]);

--- a/src/doc/examples/ol-stop-finder.js
+++ b/src/doc/examples/ol-stop-finder.js
@@ -25,7 +25,7 @@ export default () => {
     url: 'https://maps.geops.io/styles/travic_v2/style.json',
     apiKey: window.apiKey,
   });
-  mapboxLayer.init(map);
+  mapboxLayer.attachToMap(map);
 
   map.on('singleclick', () => stopFinder.clear());
 };

--- a/src/doc/examples/ol-tracker.js
+++ b/src/doc/examples/ol-tracker.js
@@ -19,13 +19,13 @@ export default () => {
   });
 
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   const layer = new MaplibreLayer({
     url: 'https://maps.geops.io/styles/travic_v2/style.json',
     apiKey: window.apiKey,
   });
-  layer.init(map);
+  layer.attachToMap(map);
 
   const tracker = new TralisLayer({
     url: 'wss://api.geops.io/tracker-ws/v1/',
@@ -33,7 +33,7 @@ export default () => {
     style: trackerDelayStyle,
     sort: sortByDelay,
   });
-  tracker.init(map);
+  tracker.attachToMap(map);
 
   tracker.onClick(([feature]) => {
     if (feature) {

--- a/src/doc/examples/ol-tralis.js
+++ b/src/doc/examples/ol-tralis.js
@@ -16,13 +16,13 @@ export default () => {
   });
 
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   const layer = new MapboxLayer({
     url: 'https://maps.geops.io/styles/travic_v2/style.json',
     apiKey: window.apiKey,
   });
-  layer.init(map);
+  layer.attachToMap(map);
 
   const tracker = new TralisLayer({
     url: 'wss://api.geops.io/tracker-ws/v1/',
@@ -34,7 +34,7 @@ export default () => {
     // projection: 'EPSG:3857',
     // regexPublishedLineName: '^(S|R$|RE|PE|D|IRE|RB|TER)',
   });
-  tracker.init(map);
+  tracker.attachToMap(map);
   tracker.onClick(([feature]) => {
     if (feature) {
       // eslint-disable-next-line no-console
@@ -52,6 +52,6 @@ export default () => {
     tracker.api.conn.websocket.send(`BBOX ${tracker.api.bbox.join(' ')}`);
   };
   document.getElementById('terminate').onclick = () => {
-    tracker.api.conn.websocket.terminate();
+    tracker.api.conn.websocket.detachFromMap();
   };
 };

--- a/src/doc/examples/tralis-live-map.js
+++ b/src/doc/examples/tralis-live-map.js
@@ -16,7 +16,7 @@ export default () => {
   });
 
   const control = new CopyrightControl();
-  control.map = map;
+  control.attachToMap(map);
 
   const cache = {};
   const tracker = new TralisLayer({
@@ -47,5 +47,5 @@ export default () => {
     }
   });
 
-  tracker.init(map);
+  tracker.attachToMap(map);
 };

--- a/src/mapbox/controls/CopyrightControl.js
+++ b/src/mapbox/controls/CopyrightControl.js
@@ -18,7 +18,7 @@ import { getMapboxMapCopyrights } from '../../common/utils';
  * });
  *
  * const control = new CopyrightControl();
- * control.map = map;
+ * control.attachToMap(map);
  *
  *
  * @see <a href="/example/mb-copyright">Mapbox copyright example</a>

--- a/src/mapbox/layers/Layer.js
+++ b/src/mapbox/layers/Layer.js
@@ -22,8 +22,8 @@ class Layer extends LayerCommon {
    * Initialize the layer and listen to user events.
    * @param {ol/Map~Map} map
    */
-  init(map) {
-    super.init(map);
+  attachToMap(map) {
+    super.attachToMap(map);
 
     if (!this.map) {
       return;
@@ -38,13 +38,13 @@ class Layer extends LayerCommon {
     }
   }
 
-  terminate(map) {
+  detachFromMap(map) {
     if (this.map) {
       this.map.off('mousemove', this.onUserMoveCallback);
       this.map.off('click', this.onUserClickCallback);
       unByKey(this.onChangeVisibleKey);
     }
-    super.terminate(map);
+    super.detachFromMap(map);
   }
 
   /**

--- a/src/mapbox/layers/Layer.test.js
+++ b/src/mapbox/layers/Layer.test.js
@@ -62,8 +62,8 @@ describe('Layer', () => {
 
   test('should call terminate on initialization.', () => {
     const layer = new Layer({ name: 'Layer' });
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init(map);
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap(map);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -73,7 +73,7 @@ describe('Layer', () => {
     expect(layer.visible).toBe(true);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -113,7 +113,7 @@ describe('Layer', () => {
     expect(layer.visible).toBe(false);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -148,13 +148,13 @@ describe('Layer', () => {
     global.console.error.mockRestore();
   });
 
-  test('should not listen for click/hover events  after layer.terminate()', async () => {
+  test('should not listen for click/hover events  after layer.detachFromMap()', async () => {
     global.console.error = jest.fn();
     const layer = new Layer({ name: 'Layer', visible: true });
     expect(layer.visible).toBe(true);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -174,7 +174,7 @@ describe('Layer', () => {
     spy.mockReset();
     spy2.mockReset();
 
-    layer.terminate(map);
+    layer.detachFromMap(map);
     await map.fire('mousemove', {
       type: 'mousemove',
       lngLat: { toArray: () => [0, 0] },

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -53,14 +53,14 @@ class TralisLayer extends mixin(Layer) {
    * @param {string} beforeId Layer's id before which we want to add the new layer.
    * @override
    */
-  init(map, beforeId) {
+  attachToMap(map, beforeId) {
     if (!map) {
       return;
     }
 
     const canvas = map.getCanvas();
 
-    super.init(map, {
+    super.attachToMap(map, {
       width: canvas.width / this.pixelRatio,
       height: canvas.height / this.pixelRatio,
     });
@@ -101,7 +101,7 @@ class TralisLayer extends mixin(Layer) {
   /**
    * Remove listeners from the Mapbox Map.
    */
-  terminate() {
+  detachFromMap() {
     if (this.map) {
       this.map.off('load', this.onLoad);
 
@@ -115,7 +115,7 @@ class TralisLayer extends mixin(Layer) {
         this.map.removeSource(this.key);
       }
     }
-    super.terminate();
+    super.detachFromMap();
   }
 
   /**

--- a/src/ol/controls/CopyrightControl.js
+++ b/src/ol/controls/CopyrightControl.js
@@ -14,7 +14,7 @@ import removeDuplicate from '../../common/utils/removeDuplicate';
  *   target: 'map',
  * });
  * const control = new CopyrightControl();
- * control.map = map
+ * control.attachToMap(map)
  *
  *
  * @see <a href="/example/ol-copyright">Openlayers copyright example</a>

--- a/src/ol/controls/CopyrightControl.test.js
+++ b/src/ol/controls/CopyrightControl.test.js
@@ -49,7 +49,7 @@ describe('CopyrightControl', () => {
         zoom: 0,
       }),
     });
-    getLayer(true, 'bar').init(map);
+    getLayer(true, 'bar').attachToMap(map);
     map.setSize([200, 200]);
     map.renderSync();
   });
@@ -68,41 +68,41 @@ describe('CopyrightControl', () => {
 
   test('renders a string copyright', () => {
     const control = new CopyrightControl();
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.innerHTML).toBe('');
-    getLayer('copyright').init(map);
+    getLayer('copyright').attachToMap(map);
     map.renderSync();
     expect(control.element.innerHTML).toBe('copyright');
   });
 
   test('renders an array of copyrights', () => {
     const control = new CopyrightControl();
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.innerHTML).toBe('');
-    getLayer(['copyright 1', 'copyright 2']).init(map);
+    getLayer(['copyright 1', 'copyright 2']).attachToMap(map);
     map.renderSync();
     expect(control.element.innerHTML).toBe('copyright 1 | copyright 2');
   });
 
   test('renders unique copyrights', () => {
     const control = new CopyrightControl();
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.innerHTML).toBe('');
-    getLayer(['copyright 1', 'copyright 2']).init(map);
-    getLayer('copyright 1').init(map);
-    getLayer(['copyright 2']).init(map);
+    getLayer(['copyright 1', 'copyright 2']).attachToMap(map);
+    getLayer('copyright 1').attachToMap(map);
+    getLayer(['copyright 2']).attachToMap(map);
     map.renderSync();
     expect(control.element.innerHTML).toBe('copyright 1 | copyright 2');
   });
 
   test("doesn't render copyright of an hidden layer", () => {
     const control = new CopyrightControl();
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.innerHTML).toBe('');
     const layer1 = getLayer('copyright hidden', false);
-    layer1.init(map);
+    layer1.attachToMap(map);
     const layer2 = getLayer('copyright', true);
-    layer2.init(map);
+    layer2.attachToMap(map);
     map.renderSync();
     expect(control.element.innerHTML).toBe('copyright');
 
@@ -115,9 +115,9 @@ describe('CopyrightControl', () => {
   });
 
   test('should activate the control on construction then deactivate it', () => {
-    getLayer('copyright 1').init(map);
+    getLayer('copyright 1').attachToMap(map);
     const control = new CopyrightControl({ active: true });
-    control.map = map;
+    control.attachToMap(map);
     map.renderSync();
 
     expect(control.element.parentNode).toBe(map.getTargetElement());
@@ -133,9 +133,9 @@ describe('CopyrightControl', () => {
   });
 
   test('should deactivate the control on constrcution then activate it', () => {
-    getLayer('copyright 1').init(map);
+    getLayer('copyright 1').attachToMap(map);
     const control = new CopyrightControl({ active: false });
-    control.map = map;
+    control.attachToMap(map);
     map.renderSync();
 
     expect(control.element.parentNode).toBe(map.getTargetElement());
@@ -152,22 +152,22 @@ describe('CopyrightControl', () => {
   });
 
   test('should add copyrights in the map container element then remove it.', () => {
-    getLayer('copyright value').init(map);
+    getLayer('copyright value').attachToMap(map);
     map.renderSync();
 
     const control = new CopyrightControl();
 
     // Add control
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.parentNode).toBe(map.getTargetElement());
 
     // Remove control
-    control.map = null;
+    control.detachFromMap();
     expect(control.element.parentNode).toBe(null);
   });
 
   test('should add copyrights in the target element then remove it.', () => {
-    getLayer(['copyright value']).init(map);
+    getLayer(['copyright value']).attachToMap(map);
     map.renderSync();
 
     const target = document.createElement('div');
@@ -179,11 +179,11 @@ describe('CopyrightControl', () => {
     });
 
     // Add control
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element.parentNode).toBe(target);
 
     // Remove control
-    control.map = null;
+    control.detachFromMap();
     expect(control.element.parentNode).toBe(null);
   });
 
@@ -199,8 +199,8 @@ describe('CopyrightControl', () => {
           : '';
       },
     });
-    control.map = map;
-    getLayer(['copyright 1', 'copyright 2', 'copyright 3']).init(map);
+    control.attachToMap(map);
+    getLayer(['copyright 1', 'copyright 2', 'copyright 3']).attachToMap(map);
     map.renderSync();
 
     // Add control

--- a/src/ol/controls/RoutingControl.js
+++ b/src/ol/controls/RoutingControl.js
@@ -54,7 +54,7 @@ const getFlatCoordinatesFromSegments = (segmentArray) => {
  *
  * const control = new RoutingControl();
  *
- * control.map = map
+ * control.attachToMap(map)
  *
  * @classproperty {string} apiKey - Key used for RoutingApi requests.
  * @classproperty {string} stopsApiKey - Key used for Stop lookup requests (defaults to apiKey).
@@ -726,7 +726,7 @@ class RoutingControl extends Control {
       this.map.removeInteraction(this.modifyInteraction);
 
       // Add modify interaction, RoutingLayer and listeners
-      this.routingLayer.init(this.map);
+      this.routingLayer.attachToMap(this.map);
       this.map.addInteraction(this.modifyInteraction);
       this.modifyInteraction.setActive(this.modify);
       this.addListeners();
@@ -740,7 +740,7 @@ class RoutingControl extends Control {
   deactivate() {
     if (this.map) {
       // Remove modify interaction, RoutingLayer, listeners and viaPoints
-      this.routingLayer.terminate(this.map);
+      this.routingLayer.detachFromMap(this.map);
       this.map.removeInteraction(this.modifyInteraction);
       this.removeListeners();
       this.reset();

--- a/src/ol/controls/RoutingControl.test.js
+++ b/src/ol/controls/RoutingControl.test.js
@@ -50,7 +50,7 @@ describe('RoutingControl', () => {
       url: 'https://foo.ch',
       apiKey: 'foo',
     });
-    control.map = map;
+    control.attachToMap(map);
     expect(map.getTarget().querySelector('#ol-toggle-routing')).toBeDefined();
     control.viaPoints = [
       [950476.4055933182, 6003322.253698345],
@@ -95,7 +95,7 @@ describe('RoutingControl', () => {
         ['osm', 14, 99],
       ],
     });
-    control.map = map;
+    control.attachToMap(map);
     control.viaPoints = ['a4dca961d199ff76', 'e3666f03cba06b2b'];
     control
       .drawRoute(control.viaPoints)
@@ -136,7 +136,7 @@ describe('RoutingControl', () => {
       url: 'https://foo.ch',
       apiKey: 'foo',
     });
-    control.map = map;
+    control.attachToMap(map);
     control.viaPoints = [
       [950476.4055933182, 6003322.253698345],
       [950389.0813034325, 6003656.659274571],
@@ -160,7 +160,7 @@ describe('RoutingControl', () => {
       apiKey: 'foo',
       snapToClosestStation: true,
     });
-    control.map = map;
+    control.attachToMap(map);
     expect(map.getTarget().querySelector('#ol-toggle-routing')).toBeDefined();
     control.viaPoints = [
       [950476.4055933182, 6003322.253698345],
@@ -190,7 +190,7 @@ describe('RoutingControl', () => {
       apiKey: 'foo',
       useRawViaPoints: true,
     });
-    control.map = map;
+    control.attachToMap(map);
     expect(map.getTarget().querySelector('#ol-toggle-routing')).toBeDefined();
     control.viaPoints = [
       '46.2,7.1',

--- a/src/ol/controls/StopFinderControl.js
+++ b/src/ol/controls/StopFinderControl.js
@@ -17,7 +17,7 @@ import mixin from '../../common/mixins/SearchMixin';
  *   apiKey: [yourApiKey]
  * });
  *
- * control.map = map;
+ * control.attachToMap(map);
  *
  *
  * @see <a href="/example/ol-search">Openlayers search example</a>

--- a/src/ol/controls/StopFinderControl.test.js
+++ b/src/ol/controls/StopFinderControl.test.js
@@ -43,7 +43,7 @@ describe('StopFinderControl', () => {
         foo: 'bar',
       },
     });
-    control.map = map;
+    control.attachToMap(map);
     expect(control.element).toBeDefined();
     control.search('foo').then(() => {
       // Correct url

--- a/src/ol/layers/Layer.js
+++ b/src/ol/layers/Layer.js
@@ -60,8 +60,8 @@ class Layer extends LayerCommon {
    * Initialize the layer and listen to feature clicks.
    * @param {ol/Map~Map} map
    */
-  init(map) {
-    super.init(map);
+  attachToMap(map) {
+    super.attachToMap(map);
 
     if (!this.map) {
       return;
@@ -74,7 +74,7 @@ class Layer extends LayerCommon {
     this.olListenersKeys.push(
       this.map.getLayers().on('remove', (evt) => {
         if (evt.element === this.olLayer) {
-          this.terminate();
+          this.detachFromMap();
         }
       }),
     );
@@ -105,14 +105,14 @@ class Layer extends LayerCommon {
   /**
    * Terminate what was initialized in init function. Remove layer, events...
    */
-  terminate() {
+  detachFromMap() {
     unByKey(this.olListenersKeys);
 
     if (this.map && this.olLayer) {
       this.map.removeLayer(this.olLayer);
     }
 
-    super.terminate();
+    super.detachFromMap();
   }
 
   /**

--- a/src/ol/layers/Layer.test.js
+++ b/src/ol/layers/Layer.test.js
@@ -47,31 +47,31 @@ describe('Layer', () => {
 
   test('should call terminate on initialization.', () => {
     const layer = new Layer({ name: 'Layer', olLayer });
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init();
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   test('should remove the layer when we call terminate.', () => {
     const layer = new Layer({ name: 'Layer', olLayer });
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init(map);
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap(map);
     expect(spy).toHaveBeenCalledTimes(1);
-    layer.terminate(map);
+    layer.detachFromMap(map);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
   test('should manage copyrights as string.', () => {
     const spy = jest.spyOn(VectorSource.prototype, 'setAttributions');
     const layer = new Layer({ name: 'Layer', copyrights: 'foo', olLayer });
-    layer.init(map);
+    layer.attachToMap(map);
     expect(spy).toHaveBeenCalledWith(['foo']);
   });
 
   test('should manage copyrights as array.', () => {
     const spy = jest.spyOn(VectorSource.prototype, 'setAttributions');
     const layer = new Layer({ name: 'Layer', copyrights: ['bar'], olLayer });
-    layer.init(map);
+    layer.attachToMap(map);
     expect(spy).toHaveBeenCalledWith(['bar']);
   });
 
@@ -82,7 +82,7 @@ describe('Layer', () => {
       copyrights: ['bar'],
       olLayer: new Group({ layers: [olLayer] }),
     });
-    layer.init(map);
+    layer.attachToMap(map);
     expect(spy).toHaveBeenCalledWith(['bar']);
   });
 
@@ -92,7 +92,7 @@ describe('Layer', () => {
     expect(layer.visible).toBe(true);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -119,7 +119,7 @@ describe('Layer', () => {
     expect(layer.visible).toBe(false);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -140,13 +140,13 @@ describe('Layer', () => {
     global.console.error.mockRestore();
   });
 
-  test('should not listen for click/hover events  after layer.terminate()', async () => {
+  test('should not listen for click/hover events  after layer.detachFromMap()', async () => {
     global.console.error = jest.fn();
     const layer = new Layer({ name: 'Layer', olLayer, visible: true });
     expect(layer.visible).toBe(true);
     const spy = jest.fn();
     const spy2 = jest.fn();
-    layer.init(map);
+    layer.attachToMap(map);
     layer.onHover(spy);
     layer.onClick(spy2);
     expect(spy).toHaveBeenCalledTimes(0);
@@ -167,7 +167,7 @@ describe('Layer', () => {
     spy.mockReset();
     spy2.mockReset();
 
-    layer.terminate(map);
+    layer.detachFromMap(map);
     await map.dispatchEvent({
       type: 'pointermove',
       map,

--- a/src/ol/layers/MapboxLayer.js
+++ b/src/ol/layers/MapboxLayer.js
@@ -154,8 +154,8 @@ export default class MapboxLayer extends Layer {
    * Initialize the layer and listen to feature clicks.
    * @param {ol/Map~Map} map
    */
-  init(map) {
-    super.init(map);
+  attachToMap(map) {
+    super.attachToMap(map);
 
     if (!this.map || this.mbMap) {
       return;
@@ -189,7 +189,7 @@ export default class MapboxLayer extends Layer {
   /**
    * Terminate what was initialized in init function. Remove layer, events...
    */
-  terminate() {
+  detachFromMap() {
     if (this.mbMap) {
       this.mbMap.off('idle', this.updateAttribution);
       // Some asynchrone repaints are triggered even if the mbMap has been removed,
@@ -199,7 +199,7 @@ export default class MapboxLayer extends Layer {
       this.mbMap = null;
     }
     this.loaded = false;
-    super.terminate();
+    super.detachFromMap();
   }
 
   /**

--- a/src/ol/layers/MapboxLayer.test.js
+++ b/src/ol/layers/MapboxLayer.test.js
@@ -31,12 +31,12 @@ describe('MapboxLayer', () => {
     });
 
     test('should not initalized mapbox map.', () => {
-      layer.init();
+      layer.attachToMap();
       expect(layer.mbMap).toBe();
     });
 
     test('should initalized mapbox map and warn the user if there is no api key defined.', () => {
-      layer.init(map);
+      layer.attachToMap(map);
       expect(layer.mbMap).toBeInstanceOf(gllib.Map);
       expect(consoleOutput[0]).toBe(
         'No apiKey is defined for request to foo.com/styles',
@@ -44,8 +44,8 @@ describe('MapboxLayer', () => {
     });
 
     test('should called terminate on initalization.', () => {
-      const spy = jest.spyOn(layer, 'terminate');
-      layer.init();
+      const spy = jest.spyOn(layer, 'detachFromMap');
+      layer.attachToMap();
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -76,7 +76,7 @@ describe('MapboxLayer', () => {
     });
 
     test('should not initalized mapbox map.', () => {
-      layer.init();
+      layer.attachToMap();
       expect(layer.mbMap).toBe();
     });
 
@@ -86,7 +86,7 @@ describe('MapboxLayer', () => {
         url: styleUrl,
         apiKey: 'apiKeyVal',
       });
-      layer1.init(map);
+      layer1.attachToMap(map);
       expect(layer1.mbMap.options.style).toBe('foo.com/styles?key=apiKeyVal');
     });
 
@@ -97,7 +97,7 @@ describe('MapboxLayer', () => {
         apiKey: 'test',
         apiKeyName: 'apiKey',
       });
-      layer1.init(map);
+      layer1.attachToMap(map);
       expect(layer1.mbMap.options.style).toBe('foo.com/styles?apiKey=test');
     });
   });
@@ -111,7 +111,7 @@ describe('MapboxLayer', () => {
         apiKey: 'test',
         apiKeyName: 'apiKey',
       });
-      layer1.init(map);
+      layer1.attachToMap(map);
       layer1.mbMap.isStyleLoaded = jest.fn(() => true);
       layer1.mbMap.getSource = jest.fn(() => true);
     });

--- a/src/ol/layers/MapboxStyleLayer.js
+++ b/src/ol/layers/MapboxStyleLayer.js
@@ -124,11 +124,11 @@ class MapboxStyleLayer extends Layer {
    * @param {mapboxgl.Map} map the mapbox map.
    * @override
    */
-  init(map) {
+  attachToMap(map) {
     if (!this.mapboxLayer.map) {
-      this.mapboxLayer.init(map);
+      this.mapboxLayer.attachToMap(map);
     }
-    super.init(map);
+    super.attachToMap(map);
 
     if (!this.map) {
       return;
@@ -141,7 +141,7 @@ class MapboxStyleLayer extends Layer {
       // relaunch the initialisation when it's the case.
       this.olListenersKeys.push(
         this.map.on('change:target', () => {
-          this.init(map);
+          this.attachToMap(map);
         }),
       );
 
@@ -179,13 +179,13 @@ class MapboxStyleLayer extends Layer {
    * @param {mapboxgl.Map} map the mapbox map.
    * @override
    */
-  terminate(map) {
+  detachFromMap(map) {
     const { mbMap } = this.mapboxLayer;
     if (mbMap) {
       mbMap.off('load', this.onLoad);
       this.removeStyleLayers();
     }
-    super.terminate(map);
+    super.detachFromMap(map);
   }
 
   /** @ignore */

--- a/src/ol/layers/MapboxStyleLayer.test.js
+++ b/src/ol/layers/MapboxStyleLayer.test.js
@@ -36,10 +36,10 @@ describe('MapboxStyleLayer', () => {
 
   afterEach(() => {
     if (layer.map) {
-      layer.terminate(map);
+      layer.detachFromMap(map);
     }
     if (source.map) {
-      source.terminate(map);
+      source.detachFromMap(map);
     }
   });
 
@@ -50,17 +50,17 @@ describe('MapboxStyleLayer', () => {
   });
 
   test('should not initalized mapbox map.', () => {
-    layer.init();
+    layer.attachToMap();
     expect(layer.mbMap).toBe();
-    layer.terminate();
+    layer.detachFromMap();
   });
 
   test('should initalized mapbox map.', () => {
-    source.init(map);
-    layer.init(map);
+    source.attachToMap(map);
+    layer.attachToMap(map);
     expect(layer.mapboxLayer.mbMap).toBeInstanceOf(gllib.Map);
-    layer.terminate();
-    source.terminate();
+    layer.detachFromMap();
+    source.detachFromMap();
   });
 
   test('should add onClick callback.', () => {
@@ -70,48 +70,48 @@ describe('MapboxStyleLayer', () => {
   });
 
   test('should called terminate on initalization.', () => {
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init();
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap();
     expect(spy).toHaveBeenCalledTimes(1);
-    layer.terminate(map);
+    layer.detachFromMap(map);
   });
 
   test('should return coordinates, features and a layer instance.', async () => {
-    source.init(map);
-    layer.init(map);
+    source.attachToMap(map);
+    layer.attachToMap(map);
     const data = await layer.getFeatureInfoAtCoordinate([50, 50]);
     expect(data.coordinate).toEqual([50, 50]);
     expect(data.features).toEqual([]);
     expect(data.layer).toBeInstanceOf(MapboxStyleLayer);
-    layer.terminate(map);
-    source.terminate(map);
+    layer.detachFromMap(map);
+    source.detachFromMap(map);
   });
 
   test('should call onClick callback', async () => {
     const coordinate = [500, 500];
     const features = [];
     const evt = { type: 'singleclick', map, coordinate };
-    layer.init(map);
+    layer.attachToMap(map);
     expect(onClick).toHaveBeenCalledTimes(0);
     await map.dispatchEvent(evt);
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith(features, layer, coordinate);
-    layer.terminate();
+    layer.detachFromMap();
   });
 
   test('should call super class terminate function.', () => {
-    layer.init(map);
-    const spy = jest.spyOn(Layer.prototype, 'terminate');
-    layer.terminate(map);
+    layer.attachToMap(map);
+    const spy = jest.spyOn(Layer.prototype, 'detachFromMap');
+    layer.detachFromMap(map);
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 
   test('should call super class terminate if the mapboxLayer associated has been terminated before.', () => {
-    layer.init(map);
-    source.terminate(map);
-    const spy = jest.spyOn(Layer.prototype, 'terminate');
-    layer.terminate(map);
+    layer.attachToMap(map);
+    source.detachFromMap(map);
+    const spy = jest.spyOn(Layer.prototype, 'detachFromMap');
+    layer.detachFromMap(map);
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
@@ -174,7 +174,7 @@ describe('MapboxStyleLayer', () => {
 
   describe('#getFeatureInfoAtCoordinate()', () => {
     beforeEach(() => {
-      source.init(map);
+      source.attachToMap(map);
       source.mbMap.isStyleLoaded = jest.fn(() => true);
       source.mbMap.getSource = jest.fn(() => true);
     });
@@ -187,7 +187,7 @@ describe('MapboxStyleLayer', () => {
       source.mbMap.getStyle = jest.fn(() => ({
         layers: [{ id: 'foo' }, { id: 'layer' }, { id: 'bar' }],
       }));
-      layer.init(map);
+      layer.attachToMap(map);
       layer.mapboxLayer.getFeatureInfoAtCoordinate = jest.fn(() =>
         Promise.resolve({ features: [] }),
       );
@@ -211,7 +211,7 @@ describe('MapboxStyleLayer', () => {
         styleLayer,
         styleLayersFilter: ({ id }) => /foo/.test(id),
       });
-      layer2.init(map);
+      layer2.attachToMap(map);
       layer2.mapboxLayer.getFeatureInfoAtCoordinate = jest.fn(() =>
         Promise.resolve({ features: [] }),
       );
@@ -244,7 +244,7 @@ describe('MapboxStyleLayer', () => {
         styleLayersFilter: ({ id }) => /foo/.test(id),
         queryRenderedLayersFilter: ({ id }) => /bar/.test(id),
       });
-      layer2.init(map);
+      layer2.attachToMap(map);
       layer2.mapboxLayer.getFeatureInfoAtCoordinate = jest.fn(() =>
         Promise.resolve({ features: [] }),
       );

--- a/src/ol/layers/MaplibreLayer.js
+++ b/src/ol/layers/MaplibreLayer.js
@@ -107,8 +107,8 @@ export default class MaplibreLayer extends Layer {
    * Initialize the layer and listen to feature clicks.
    * @param {ol/Map~Map} map
    */
-  init(map) {
-    super.init(map);
+  attachToMap(map) {
+    super.attachToMap(map);
 
     if (!this.map) {
       return;
@@ -128,7 +128,7 @@ export default class MaplibreLayer extends Layer {
   /**
    * Terminate what was initialized in init function. Remove layer, events...
    */
-  terminate() {
+  detachFromMap() {
     if (this.mbMap) {
       this.mbMap.off('idle', this.updateAttribution);
       // Some asynchrone repaints are triggered even if the mbMap has been removed,
@@ -138,7 +138,7 @@ export default class MaplibreLayer extends Layer {
       this.mbMap = null;
     }
     this.loaded = false;
-    super.terminate();
+    super.detachFromMap();
   }
 
   /**

--- a/src/ol/layers/RoutingLayer.test.js
+++ b/src/ol/layers/RoutingLayer.test.js
@@ -32,11 +32,11 @@ describe('RoutingLayer', () => {
   });
 
   test('should called terminate on initalization.', () => {
-    const spy = jest.spyOn(layer, 'terminate');
+    const spy = jest.spyOn(layer, 'detachFromMap');
 
     fetch.mockResponseOnce(JSON.stringify(global.fetchTrajectoriesResponse));
 
-    layer.init(olMap);
+    layer.attachToMap(olMap);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 

--- a/src/ol/layers/TralisLayer.js
+++ b/src/ol/layers/TralisLayer.js
@@ -120,8 +120,8 @@ class TralisLayer extends mixin(Layer) {
     };
   }
 
-  init(map) {
-    super.init(map);
+  attachToMap(map) {
+    super.attachToMap(map);
     if (this.map) {
       this.olListenersKeys.push(
         this.map.on(['moveend', 'change:target'], (evt) => {
@@ -146,8 +146,8 @@ class TralisLayer extends mixin(Layer) {
   /**
    * Destroy the container of the tracker.
    */
-  terminate() {
-    super.terminate();
+  detachFromMap() {
+    super.detachFromMap();
     this.container = null;
   }
 

--- a/src/ol/layers/TralisLayer.test.js
+++ b/src/ol/layers/TralisLayer.test.js
@@ -46,11 +46,11 @@ describe('TralisLayer', () => {
   });
 
   test('should called terminate on initalization.', () => {
-    const spy = jest.spyOn(layer, 'terminate');
+    const spy = jest.spyOn(layer, 'detachFromMap');
 
     fetch.mockResponseOnce(JSON.stringify(global.fetchTrajectoriesResponse));
 
-    layer.init(olMap);
+    layer.attachToMap(olMap);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 

--- a/src/ol/layers/VectorLayer.test.js
+++ b/src/ol/layers/VectorLayer.test.js
@@ -59,8 +59,8 @@ describe('VectorLayer', () => {
   });
 
   test('should called terminate on initalization.', () => {
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init();
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -74,7 +74,7 @@ describe('VectorLayer', () => {
     const spy3 = jest
       .spyOn(map, 'getFeaturesAtPixel')
       .mockReturnValue(features);
-    layer.init(map);
+    layer.attachToMap(map);
     expect(onClick).toHaveBeenCalledTimes(0);
     await map.dispatchEvent(evt);
     expect(spy).toHaveBeenCalledTimes(1);

--- a/src/ol/layers/WMSLayer.test.js
+++ b/src/ol/layers/WMSLayer.test.js
@@ -23,13 +23,13 @@ describe('WMSLayer', () => {
         }),
       }),
     });
-    layer.init(map);
+    layer.attachToMap(map);
     fetch.mockResponseOnce(JSON.stringify({ features: [] }));
     global.fetch = fetch;
   });
 
   afterEach(() => {
-    layer.terminate();
+    layer.detachFromMap();
   });
 
   test('should initialize.', () => {
@@ -37,8 +37,8 @@ describe('WMSLayer', () => {
   });
 
   test('should called terminate on initalization.', () => {
-    const spy = jest.spyOn(layer, 'terminate');
-    layer.init();
+    const spy = jest.spyOn(layer, 'detachFromMap');
+    layer.attachToMap();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Init() an terminate() were not very usert friendly so we change them for attachToMap and removeFromMap.

We also add  that theese function add /remove the olLayer from the map.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] The new class' members & methods are well documented
- [x] Tests added.
